### PR TITLE
fix typo

### DIFF
--- a/docs/xamarin-forms/app-fundamentals/index.yml
+++ b/docs/xamarin-forms/app-fundamentals/index.yml
@@ -30,7 +30,7 @@ landingContent:
       url: app-lifecycle.md
     - text: 数据绑定
       url: data-binding/index.md
-    - text: 笔势
+    - text: 手势
       url: gestures/index.md
     - text: 本地化
       url: localization/index.md


### PR DESCRIPTION
On the website "https://docs.microsoft.com/zh-cn/xamarin/xamarin-forms/app-fundamentals/gestures/", all the words "Gesture" are translated into "手势", which does match the the label.